### PR TITLE
Update ETSC chainId

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -362,7 +362,7 @@ nodes.nodeList = {
         'blockExplorerAddr': 'https://explorer.ethereumsocial.kr/addr/[[address]]',
         'type': nodes.nodeTypes.ETSC,
         'eip155': true,
-        'chainId': 214,
+        'chainId': 28,
         'tokenList': require('./tokens/etscTokens.json'),
         'abiList': require('./abiDefinitions/etscAbi.json'),
         'estimateGas': true,


### PR DESCRIPTION
This patch makes ClassicEtherWallet compatible from the new chain's spec.

The new chain is based on Classic Geth and we will shut down the node api for a moment.