### PR TITLE
disable EIP-155 for PIRL just as was done for CLO

### DIFF
--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -491,6 +491,18 @@
 
                         <div class="col-sm-4">
                             <label class="radio small">
+                                <input aria-describedby="Path: Ledger (PIRL) {{HDWallet.hwPirlPath}}"
+                                       ng-change="onHDDPathChange()"
+                                       ng-model="HDWallet.dPath"
+                                       type="radio"
+                                       value="{{HDWallet.hwPirlPath}}"/>
+                                <span ng-bind="HDWallet.hwPirlPath"></span>
+                                <p class="small">Network: PIRL</p>
+                            </label>
+                        </div>
+
+                        <div class="col-sm-4">
+                            <label class="radio small">
                                 <input aria-describedby="Path: TREZOR (CLO) {{HDWallet.hwCallistoPath}}"
                                        ng-change="onHDDPathChange()"
                                        ng-model="HDWallet.dPath"

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -372,6 +372,7 @@ globalFuncs.HDWallet = {
     hwMusicoinPath: "m/44'/184'/0'/0",      // first address: m/44'/184'/0'/0/0
     hwRskPath: "m/44'/137'/0'/0",      // first address : m/44'/137'/0'/0/0
     hwESNetworkPath: "m/44'/31102'/0'/0",      // first address : m/44'/31102'/0'/0/0
+    hwPirlPath: "m/44'/164'/0'/0",      // first address: m/44'/164'/0'/0/0
 };
 
 globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.nodeTypes.CLO) {
@@ -386,6 +387,8 @@ globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.no
                 return globalFuncs.HDWallet.hwExpansePath;
             case nodes.nodeTypes.UBQ:
                 return globalFuncs.HDWallet.hwUbqPath;
+            case nodes.nodeTypes.PIRL:
+                return globalFuncs.HDWallet.hwPirlPath;
             default:
                 return globalFuncs.HDWallet.ledgerPath;
         }
@@ -421,6 +424,8 @@ globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.no
                 return globalFuncs.HDWallet.hwMusicoinPath;
             case nodes.nodeTypes.ESN:
                 return globalFuncs.HDWallet.hwESNetworkPath;
+            case nodes.nodeTypes.PIRL:
+                return globalFuncs.HDWallet.hwPirlPath;
             default:
                 return globalFuncs.HDWallet.defaultDPath;
         }
@@ -452,6 +457,8 @@ globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.no
                 return globalFuncs.HDWallet.hwMusicoinPath;
             case nodes.nodeTypes.ESN:
                 return globalFuncs.HDWallet.hwESNetworkPath;
+            case nodes.nodeTypes.PIRL:
+                return globalFuncs.HDWallet.hwPirlPath;
             default:
                 return globalFuncs.HDWallet.defaultDPath;
         }

--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -39,7 +39,10 @@ uiFuncs.isTxDataValid = function (txData) {
 
 
  */
-const removeChainIdIfCLO = (chainId) => parseInt(chainId) === 820 ? null : chainId;
+const removeChainIdIfUnwanted = (chainId) => {
+  var cId = parseInt(chainId);
+  return (cId === 820 || cId === 3125659152) ? null : chainId;
+}
 
 
 uiFuncs.signTxTrezor = function (rawTx, txData, callback) {
@@ -65,7 +68,7 @@ uiFuncs.signTxTrezor = function (rawTx, txData, callback) {
     }
 
 
-    const chainId = removeChainIdIfCLO(rawTx.chainId);
+    const chainId = removeChainIdIfUnwanted(rawTx.chainId);
 
 
     TrezorConnect.signEthereumTx(
@@ -232,7 +235,7 @@ uiFuncs.genTxWithInfo = function (data, callback) {
                     error: error
                 });
 
-            } else if (rawTx.chainId === 820) {
+            } else if (rawTx.chainId === 820 || rawTx.chainId === 3125659152) {
 
                 EIP155Supported = false;
 


### PR DESCRIPTION
As discussed in #137 , there is an issue signing tx w/ EIP-155 support on the PIRL network just as the CLO network.

This fixes the "invalid sender" error when trying to sign a tx on the PIRL network when using a HW wallet.

Also, change the default HD Derivation path for PIRL to its own unique path of "m/44'/164'/0'/0"