### PR TITLE
update PIRL block explorer to poseidon.pirl.io

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -313,8 +313,8 @@ nodes.nodeList = {
     },
     'pirl': {
         'name': 'PIRL',
-        'blockExplorerTX': 'https://pirl.site/tx/[[txHash]]',
-        'blockExplorerAddr': 'https://pirl.site/addr/[[address]]',
+        'blockExplorerTX': 'https://poseidon.pirl.io/explorer/transaction/[[txHash]]',
+        'blockExplorerAddr': 'https://poseidon.pirl.io/explorer/address/[[address]]',
         'type': nodes.nodeTypes.PIRL,
         'eip155': true,
         'chainId': 3125659152,


### PR DESCRIPTION
pirl.site has been down for a while now.  Use poseidon.pirl.io/explorer/ instead