### PR TITLE
fix broken HD derivation path dialog box layout

### DIFF
--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -535,6 +535,7 @@
                                 <span ng-bind="HDWallet.hwESNetworkPath"></span>
                                 <p class="small">Network: Ethersocial Network</p>
                             </label>
+                        </div>
 
                             <div class="col-sm-4">
                                 <label class="radio small">


### PR DESCRIPTION
The layout of the HD Derivation Path Selection dialog box got broken in commit c9f7f9b21baa56d1779c5a2748a3cdeca7108a38 with an unbalanced `<div>`

Fix the problem by replacing the missing `</div>`