### PR TITLE
support 32bits chainId with the latest Ledger app

### DIFF
--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -83,7 +83,7 @@ uiFuncs.signTxTrezor = function (rawTx, txData, callback) {
 uiFuncs.signTxLedger = function (app, eTx, rawTx, txData, old, callback) {
 
 
-    eTx.raw[6] = Buffer.from([rawTx.chainId]);
+    eTx.raw[6] = rawTx.chainId;
 
 
     eTx.raw[7] = eTx.raw[8] = 0;
@@ -100,7 +100,17 @@ uiFuncs.signTxLedger = function (app, eTx, rawTx, txData, old, callback) {
             });
             return;
         }
-        rawTx.v = "0x" + result['v'];
+        var v = result['v'].toString(16);
+        if (!old) {
+            // EIP155 support. check/recalc signature v value.
+            var rv = parseInt(v, 16);
+            var cv = rawTx.chainId * 2 + 35;
+            if (rv !== cv && (rv & cv) !== rv) {
+                cv += 1; // add signature v bit.
+            }
+            v = cv.toString(16);
+        }
+        rawTx.v = "0x" + v;
         rawTx.r = "0x" + result['r'];
         rawTx.s = "0x" + result['s'];
         eTx = new ethUtil.Tx(rawTx);


### PR DESCRIPTION
Please see https://github.com/LedgerHQ/blue-app-eth/commit/8260268b0214810872dabd154b476f5bb859aac0
for some larger chainId cases, returned signature v should be recomputed at the client side.