### PR TITLE
Use Pirl's official HD Derivation Path "m/44'/164'/0'/0"

### DIFF
--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -491,6 +491,18 @@
 
                         <div class="col-sm-4">
                             <label class="radio small">
+                                <input aria-describedby="Path: Ledger (PIRL) {{HDWallet.hwPirlPath}}"
+                                       ng-change="onHDDPathChange()"
+                                       ng-model="HDWallet.dPath"
+                                       type="radio"
+                                       value="{{HDWallet.hwPirlPath}}"/>
+                                <span ng-bind="HDWallet.hwPirlPath"></span>
+                                <p class="small">Network: PIRL</p>
+                            </label>
+                        </div>
+
+                        <div class="col-sm-4">
+                            <label class="radio small">
                                 <input aria-describedby="Path: TREZOR (CLO) {{HDWallet.hwCallistoPath}}"
                                        ng-change="onHDDPathChange()"
                                        ng-model="HDWallet.dPath"

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -372,6 +372,7 @@ globalFuncs.HDWallet = {
     hwMusicoinPath: "m/44'/184'/0'/0",      // first address: m/44'/184'/0'/0/0
     hwRskPath: "m/44'/137'/0'/0",      // first address : m/44'/137'/0'/0/0
     hwESNetworkPath: "m/44'/31102'/0'/0",      // first address : m/44'/31102'/0'/0/0
+    hwPirlPath: "m/44'/164'/0'/0",      // first address: m/44'/164'/0'/0/0
 };
 
 globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.nodeTypes.CLO) {
@@ -386,6 +387,8 @@ globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.no
                 return globalFuncs.HDWallet.hwExpansePath;
             case nodes.nodeTypes.UBQ:
                 return globalFuncs.HDWallet.hwUbqPath;
+            case nodes.nodeTypes.PIRL:
+                return globalFuncs.HDWallet.hwPirlPath;
             default:
                 return globalFuncs.HDWallet.ledgerPath;
         }
@@ -421,6 +424,8 @@ globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.no
                 return globalFuncs.HDWallet.hwMusicoinPath;
             case nodes.nodeTypes.ESN:
                 return globalFuncs.HDWallet.hwESNetworkPath;
+            case nodes.nodeTypes.PIRL:
+                return globalFuncs.HDWallet.hwPirlPath;
             default:
                 return globalFuncs.HDWallet.defaultDPath;
         }
@@ -452,6 +457,8 @@ globalFuncs.getWalletPath = function (walletType = 'trezor', nodeType = nodes.no
                 return globalFuncs.HDWallet.hwMusicoinPath;
             case nodes.nodeTypes.ESN:
                 return globalFuncs.HDWallet.hwESNetworkPath;
+            case nodes.nodeTypes.PIRL:
+                return globalFuncs.HDWallet.hwPirlPath;
             default:
                 return globalFuncs.HDWallet.defaultDPath;
         }


### PR DESCRIPTION
Use Pirl's official HD Derivation Path "m/44'/164'/0'/0"

Support for full 32bit Chain IDs has been merged into LedgerHQ/blue-app-eth:

https://github.com/LedgerHQ/blue-app-eth/commit/8260268b0214810872dabd154b476f5bb859aac0
https://github.com/LedgerHQ/blue-app-eth/commit/74c085ca2d032179fcf205cda1dee38c92877933

The signature V component must be recalculated in the javascript.  A pull request for this new feature  is here:

https://github.com/EthereumCommonwealth/etherwallet/pull/202

This change does not depend on any of the above - it merely sets the correct HD Derivation path in ClassicEtherWallet, along with the required UI changes in the HD Derivation dialog box.

With all changes applied, the Ledger Nano S can be used with ClassicEtherWallet to safely sign transactions with EIP-155 correctly enabled.

cc: @masterdubs