### PR TITLE
enforce EIP-155 replay attack protection for Callisto (CLO) with Ledger hardware wallets

### DIFF
--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -232,10 +232,6 @@ uiFuncs.genTxWithInfo = function (data, callback) {
                     error: error
                 });
 
-            } else if (rawTx.chainId === 820) {
-
-                EIP155Supported = false;
-
             } else {
 
                 var splitVersion = result['version'].split('.');


### PR DESCRIPTION
In the past, it wasn't possible to sign transactions on the Callisto network using hardware wallets with EIP-155 replay attack protection

This issue has been solved on Ledger hardware wallets

Let's remove the hack to disable EIP-155 for Callisto on the Ledger, now enforcing replay attack protection, making Callisto as safe as any other coin to use with Ledger hardware wallets.

Those interested in testing this can build the Callisto Ledger app using the instructions that I posted in the #development channel on the Callisto discord.

depends-on #202