### PR TITLE
Fix Ledger HD Derivation Path selection for Callisto (CLO)

### DIFF
--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -473,6 +473,8 @@ globalFuncs.getWalletPath = function(
                 return globalFuncs.HDWallet.ledgerPath;
             case nodes.nodeTypes.ETC:
                 return globalFuncs.HDWallet.ledgerClassicPath;
+            case nodes.nodeTypes.CLO:
+                return globalFuncs.HDWallet.hwCallistoPath;
             case nodes.nodeTypes.EXP:
                 return globalFuncs.HDWallet.hwExpansePath;
             case nodes.nodeTypes.UBQ:


### PR DESCRIPTION
Automatically select the Callisto-specific HD Derivation Path when the dialog box is opened