### PR TITLE
support full 32bit chain_id for Trezor

### DIFF
--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -47,6 +47,13 @@ uiFuncs.signTxTrezor = function(rawTx, { path }, callback) {
             }
         }
 
+        // check the returned signature_v and recalc signature_v if it needed
+        // see also https://github.com/trezor/trezor-mcu/pull/399
+        if (result.v <= 1) {
+          // for larger chainId, only signature_v returned. simply recalc signature_v
+          result.v += 2 * rawTx.chainId + 35;
+        }
+
         rawTx.v = "0x" + ethFuncs.decimalToHex(result.v);
         rawTx.r = "0x" + result.r;
         rawTx.s = "0x" + result.s;


### PR DESCRIPTION
the following are full 32bit chain_id support fix for Trezor Hard wallet.
* Trezor nano S, full 32bit chain_id PR ***merged*** https://github.com/trezor/trezor-mcu/pull/399
* Trezor model T, full 32bit chain_id PR ***merged*** https://github.com/trezor/trezor-core/pull/311

for some larger chainId, Trezor returns only `signature_v` bit (`0` or `1`) and this fix simply recalc `signature_v` at the client side.

*there is no backward compatible issue with this fix*
(Please see https://github.com/trezor/trezor-mcu/pull/399 for details)
