### PR TITLE
Fix transaction history link text

### DIFF
--- a/app/scripts/directives/balanceDrtv.html
+++ b/app/scripts/directives/balanceDrtv.html
@@ -206,7 +206,7 @@
             <li ng-show="ajaxReq.type != 'CUS'">
                 <a href="{{ajaxReq.blockExplorerAddr.replace('[[address]]', walletService.wallet.getAddressString())}}"
                    target="_blank" rel="noopener">
-                    {{ajaxReq.type}} ({{ajaxReq.blockExplorerTX.replace('/tx/[[txHash]]', '')}})
+                    {{ajaxReq.type}} ({{ajaxReq.blockExplorerTX.match('://(.*?)/')[1]}})
                 </a>
             </li>
             <li>


### PR DESCRIPTION
The current code expects each blockExplorerTX link to be of the form:
`/tx/[[txHash]]`
and fails to display correctly if the URLs are structured otherwise:

![image](https://user-images.githubusercontent.com/1062488/44401823-e3d7b780-a51d-11e8-8389-f21b9baa32e1.png)
![image](https://user-images.githubusercontent.com/1062488/44401924-35804200-a51e-11e8-8070-73159a40aa57.png)

Instead of depending on this static text, grab the text we actually want:

![image](https://user-images.githubusercontent.com/1062488/44401845-f9e57800-a51d-11e8-87d9-933cfb60aa2c.png)
![image](https://user-images.githubusercontent.com/1062488/44401945-44ff8b00-a51e-11e8-9daf-c5fdf89120b9.png)

cc @detroitpro
cc @masterdubs
