### PR TITLE
restore Ethersocial Network(ESN) node

### DIFF
--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -483,6 +483,8 @@ globalFuncs.getWalletPath = function(
                 return globalFuncs.HDWallet.hwPirlPath;
             case nodes.nodeTypes.AKA:
                 return globalFuncs.HDWallet.hwAkromaPath;
+            case nodes.nodeTypes.ESN:
+                return globalFuncs.HDWallet.hwESNetworkPath;
             default:
                 return globalFuncs.HDWallet.ledgerPath;
         }

--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -384,6 +384,19 @@ nodes.nodeList = {
         service: "ellaism.org",
         lib: new nodes.customNode("https://jsonrpc.ellaism.org", "")
     },
+    esn: {
+        name: "ESN",
+        blockExplorerTX: "https://ethersocial.net/tx/[[txHash]]",
+        blockExplorerAddr: "https://ethersocial.net/addr/[[address]]",
+        type: nodes.nodeTypes.ESN,
+        eip155: true,
+        chainId: 31102,
+        tokenList: require("./tokens/esnTokens.json"),
+        abiList: require("./abiDefinitions/esnAbi.json"),
+        estimateGas: true,
+        service: "ethersocial.org",
+        lib: new nodes.customNode("https://api.esn.gonspool.com", "")
+    },
     aka: {
         name: "AKA",
         blockExplorerTX: "https://akroma.io/explorer/transaction/[[txHash]]",


### PR DESCRIPTION
Ethersocial Network(ESN) node accidentally removed by commit 9e17f2154f
and recently, node health check method changed by commit fffa10b44e02

We will add `net_listening` api method asap.

additionally, missing ledger support for ESN added.

cc: @magnalucus, @kimmyeonghun