### PR TITLE
partial restore full 32bit chainid support for Trezor

### DIFF
--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -49,6 +49,13 @@ uiFuncs.signTxTrezor = function(rawTx, { path }) {
             throw error;
         }
 
+        // check the returned signature_v and recalc signature_v if it needed
+        // see also https://github.com/trezor/trezor-mcu/pull/399
+        if (v <= 1) {
+            // for larger chainId, only signature_v returned. simply recalc signature_v
+            v += 2 * rawTx.chainId + 35;
+        }
+
         rawTx.v = ethFuncs.sanitizeHex(ethFuncs.decimalToHex(v));
         rawTx.r = ethFuncs.sanitizeHex(r);
         rawTx.s = ethFuncs.sanitizeHex(s);


### PR DESCRIPTION
full 32bit chainId support for Trezor accidentally removed by recent Trezor-v5 support PR.

confirmed with Pirl

See also https://github.com/kvhnuke/etherwallet/pull/2080

cc: @mkrufky 