### PR TITLE
Fix CS testnet address and description

### DIFF
--- a/app/includes/cold-staking-claimReward-modal.tpl
+++ b/app/includes/cold-staking-claimReward-modal.tpl
@@ -42,10 +42,9 @@
                     </p>
 
                     <p>
-                        <b>Warning:</b> After claiming the reward, your funds will be frozen for the next 172,800 blocks
+                        <b>Warning:</b> After claiming the reward, your funds will be frozen for the next 27 days
 
-                        (approx. 1 month) and you will be unable to claim new reward OR withdraw your funds during this
-                        period.
+                        and you will be unable to claim new reward OR withdraw your funds during this period.
                     </p>
 
 

--- a/app/includes/cold-staking-startStaking-modal.tpl
+++ b/app/includes/cold-staking-startStaking-modal.tpl
@@ -96,9 +96,8 @@
 
                     <p translate="COLD_STAKING_LOCKED_WARNING">
 
-                        Your funds will be locked for 172,800 blocks (approximately 1 month)
-                        and you will be unable to withdraw within the locking period
-
+                        Your funds will be locked for 27 days and you will be unable 
+                        to withdraw within the locking period
 
                     </p>
 

--- a/app/scripts/services/coldStaking.service.js
+++ b/app/scripts/services/coldStaking.service.js
@@ -7,7 +7,7 @@ const contract = require("../abiDefinitions/rinkebyAbi").find(
 if (!contract) throw new Error("Unable to locate cold staking contract");
 
 const addrs = {
-    "Testnet CLO": "0xa45083107ae67636cd9b93ad13c15b939dbdce31",
+    "Testnet CLO": "0xd813419749b3c2cDc94A2F9Cfcf154113264a9d6",
     "RINKEBY ETH": "0x713f80e73b174b9aba62dd75fa1da6925c13ace5"
 };
 

--- a/app/scripts/translations/en.js
+++ b/app/scripts/translations/en.js
@@ -52,7 +52,7 @@ en.data = {
         "                            You should withdraw your staking reward first or use a another account for a new staking\n" +
         "                            deposit.",
     COLD_STAKING_LOCKED_WARNING:
-        "Your funds will be locked for 172,800 blocks (approximately 1 month)\n" +
+        "Your funds will be locked for 27 days\n" +
         "                        and you will be unable to withdraw within the locking period",
 
     COLD_STAKING_PAY_TX_FEE_WARNING:


### PR DESCRIPTION
Change testnet address to 0xd813419749b3c2cDc94A2F9Cfcf154113264a9d6.
Change description about blocking time from: "172,800 blocks (approximately 1 month)" to: "27 days".